### PR TITLE
Fix identifier

### DIFF
--- a/ckan2pycsw/schemas/ckan/iso19139_base/main.j2
+++ b/ckan2pycsw/schemas/ckan/iso19139_base/main.j2
@@ -1,8 +1,13 @@
 {
     {# ISO19139 Metadata Schema #}
+    {#TODO: Improve ISO19139 base schema #}
     "mcf": {"version": 1.0},
     "metadata": {
-        "identifier": "{{ record['id'] }}",
+        {% if record['identifier'] %}
+            "identifier": "{{ record['identifier'] }}",
+        {% else %}
+            "identifier": "{{ record['id'] }}",
+        {% endif %}
         "language": "es",
         "charset": "utf8",
         "datestamp": "{{ record['metadata_modified']|normalize_datetime }}",

--- a/ckan2pycsw/schemas/ckan/iso19139_geodcatap/main.j2
+++ b/ckan2pycsw/schemas/ckan/iso19139_geodcatap/main.j2
@@ -4,7 +4,11 @@
     {% set dcat_type = record['dcat_type'].rsplit('/', 1)[-1] %}
     "mcf": {"version": 1.0},
     "metadata": {
-        "identifier": "{{ record['id'] }}",
+        {% if record['identifier'] %}
+            "identifier": "{{ record['identifier'] }}",
+        {% else %}
+            "identifier": "{{ record['id'] }}",
+        {% endif %}
         "language": "{{ language }}",
         "charset": "UTF-8",
         {% if record['source'] %}


### PR DESCRIPTION
Use ckan `identifier` ([example identifier GeoDCAT-AP schema](https://github.com/mjanez/ckanext-scheming/blob/9dcb4e3bacc86efa1accd2853d4a520d740ebf6e/ckanext/scheming/ckan_geodcatap.yaml#L497-L510)) as `pycsw['metadata']['identifier']` instead of `id` (CKAN package id) to avoid generating iso19139 metadata with a different id than the one associated to the dataset in CKAN.

Only use package id if not exists `identifier.`

```json
{
  "help": "{ckan_endpoint}/api/3/action/help_show?name=package_show",
  "success": true,
  "result": {
    "access_rights": "http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations",
    "alternate_identifier": "",
    "author": "",
    "author_email": "",
    "author_uri": "",
    "author_url": "",
    "conforms_to": "[\"http://inspire.ec.europa.eu/documents/inspire-metadata-regulation\", \"http://inspire.ec.europa.eu/documents/commission-regulation-eu-no-13122014-10-december-2014-amending-regulation-eu-no-10892010-0\", \"http://semiceu.github.io/GeoDCAT-AP/releases/2.0.0/\"]",
    "contact_email": "example@example.es",
    "contact_name": "Test organization",
    "contact_uri": "https://example.org/ID91312313",
    "contact_url": "https://example.org",
    "created": "2021-01-01",
    "creator_user_id": "e4ca2dea-876c-4093-ba2b-f9e4cec8a037",
    "dcat_type": "http://inspire.ec.europa.eu/metadata-codelist/ResourceType/dataset",
    "encoding": "UTF-8",
    "frequency": "",
    "id": "103a86b5-dee7-40b4-8864-f6f241181957",   // CKAN package id. Auto uuid
    "identifier": "spamitma_hermes_1_rtig_ib_ae_orientacionpista_en", // CKAN identifier. Mandatory in schema.
    "inspire_id": "spamitma_hermes_1_rtig_ib_ae_orientacionpista_en",

...

}
```
